### PR TITLE
feat: add admin show command

### DIFF
--- a/src/main/java/fr/maxlego08/jobs/command/commands/admin/CommandJobsAdmin.java
+++ b/src/main/java/fr/maxlego08/jobs/command/commands/admin/CommandJobsAdmin.java
@@ -24,6 +24,7 @@ public class CommandJobsAdmin extends VCommand {
         this.addSubCommand(new CommandJobsAdminPrestige(plugin));
         this.addSubCommand(new CommandJobsAdminPoints(plugin));
         this.addSubCommand(new CommandJobsAdminInfo(plugin));
+        this.addSubCommand(new CommandJobsAdminShow(plugin));
         this.addSubCommand(new CommandJobsAdminReward(plugin));
         this.addSubCommand(new CommandJobsAdminBoost(plugin));
     }

--- a/src/main/java/fr/maxlego08/jobs/command/commands/admin/CommandJobsAdminShow.java
+++ b/src/main/java/fr/maxlego08/jobs/command/commands/admin/CommandJobsAdminShow.java
@@ -1,0 +1,55 @@
+package fr.maxlego08.jobs.command.commands.admin;
+
+import fr.maxlego08.jobs.JobsPlugin;
+import fr.maxlego08.jobs.api.players.PlayerJob;
+import fr.maxlego08.jobs.command.VCommand;
+import fr.maxlego08.jobs.zcore.enums.Message;
+import fr.maxlego08.jobs.zcore.enums.Permission;
+import fr.maxlego08.jobs.zcore.utils.commands.CommandType;
+import org.bukkit.OfflinePlayer;
+
+public class CommandJobsAdminShow extends VCommand {
+
+    public CommandJobsAdminShow(JobsPlugin plugin) {
+        super(plugin);
+        this.setPermission(Permission.ZJOBS_ADMIN_SHOW);
+        this.addSubCommand("show");
+        this.setDescription(Message.DESCRIPTION_ADMIN_SHOW);
+        this.addRequireArgOfflinePlayer();
+    }
+
+    @Override
+    protected CommandType perform(JobsPlugin plugin) {
+
+        OfflinePlayer offlinePlayer = this.argAsOfflinePlayer(0);
+
+        plugin.getJobManager().loadOfflinePlayer(offlinePlayer.getUniqueId(), playerJobs -> {
+
+            message(this.plugin, sender, Message.ADMIN_POINTS_INFO, "%player%", offlinePlayer.getName(), "%points%", playerJobs.getPoints());
+
+            if (playerJobs.getJobs().isEmpty()) {
+                message(this.plugin, sender, Message.ADMIN_SHOW_EMPTY, "%player%", offlinePlayer.getName());
+                return;
+            }
+
+            int amount = playerJobs.getJobs().size();
+            message(this.plugin, sender, Message.ADMIN_SHOW_HEADER, "%player%", offlinePlayer.getName(), "%amount%", amount, "%s%", amount > 1 ? "s" : "");
+
+            for (PlayerJob playerJob : playerJobs.getJobs()) {
+                plugin.getJobManager().getJob(playerJob.getJobId()).ifPresent(job -> {
+                    double maxExperience = job.getExperience(playerJob.getLevel(), playerJob.getPrestige());
+                    message(this.plugin, sender, Message.ADMIN_SHOW_JOB_INFO,
+                            "%job%", job.getName(),
+                            "%level%", playerJob.getLevel(),
+                            "%prestige%", playerJob.getPrestige(),
+                            "%experience%", format(playerJob.getExperience()),
+                            "%max_experience%", format(maxExperience));
+                });
+            }
+
+        });
+
+        return CommandType.SUCCESS;
+    }
+}
+

--- a/src/main/java/fr/maxlego08/jobs/zcore/enums/Message.java
+++ b/src/main/java/fr/maxlego08/jobs/zcore/enums/Message.java
@@ -66,6 +66,7 @@ public enum Message {
     DESCRIPTION_ADMIN_POINTS_SET("Define points to a player"),
     DESCRIPTION_ADMIN_POINTS_REMOVE("Remove points to a player"),
     DESCRIPTION_ADMIN_BLOCK_INFO("Get information on a block"),
+    DESCRIPTION_ADMIN_SHOW("Show jobs info of a player"),
 
     PROGRESSION_BOSSBAR("#2fe082%job-name% #434343- #f7f725%job-experience%&8/#f78e25%job-max-experience% #434343- #2fe082P%job-prestige% lvl %job-level%"),
 
@@ -104,6 +105,10 @@ public enum Message {
     ADMIN_POINTS_SET("&aYou just set the points to &a%value%&a for&f %player%&a."),
     ADMIN_POINTS_REMOVE("&aYou have just removed &a%value%&a experience from &f%player%&a."),
     ADMIN_POINTS_INFO("&f%player%&8: &7%points% points"),
+
+    ADMIN_SHOW_EMPTY("&f%player% &chas no job."),
+    ADMIN_SHOW_HEADER("&7Jobs of &f%player% &8(&7%amount%&8)&7:"),
+    ADMIN_SHOW_JOB_INFO("&8- &f%job% &7level &e%level% &7prestige &e%prestige% &7experience &e%experience%&7/&e%max_experience%"),
 
     ADMIN_BLOCKINFO_ERROR("&cImpossible to find the block."),
     ADMIN_BLOCKINFO_MATERIAL(

--- a/src/main/java/fr/maxlego08/jobs/zcore/enums/Permission.java
+++ b/src/main/java/fr/maxlego08/jobs/zcore/enums/Permission.java
@@ -32,6 +32,8 @@ public enum Permission {
     ZJOBS_ADMIN_POINTS_REMOVE,
     ZJOBS_ADMIN_POINTS_INFO,
 
+    ZJOBS_ADMIN_SHOW,
+
     ZJOBS_ADMIN_REWARD_SET;
 
     private final String permission;


### PR DESCRIPTION
## Summary
- add `/zjobs admin show <player>` command to inspect all jobs of a player
- wire command into admin command tree
- include new messages and permission node for job info display

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68aee97360908321b8dc0f9f04af6be4